### PR TITLE
Adding PSTR macro to jsonKeyFind() call needs _P string functions to be used here

### DIFF
--- a/code/misc/expProtocol.h
+++ b/code/misc/expProtocol.h
@@ -32,6 +32,7 @@
 #define ID_CO2_PPM "07"					// optional: carbon dioxide in ppm
 #define ID_CH2O_PPM "08"				// optional: formaldehyde in ppm
 #define ID_PM25_UGCM "09"				// optional: particulate matter in micro grams per cubic meter
+#define ID_TUBE_TYPE "10"				// optional: tube type
 #define ID_BATTERY_VOLTS "0A"			// optional: device battery voltage in volts
 #define ID_SBM20_CPM "0B"				// optional: radiation measured on SBM20 geiger tube in cpm
 #define ID_INVERTERVOLTAGE_VOLTS "0C"	// optional: high voltage geiger tube inverter voltage in volts

--- a/code/misc/utils.cpp
+++ b/code/misc/utils.cpp
@@ -28,6 +28,7 @@
 
 #include <util/delay.h>
 #include <string.h>
+#include <avr/pgmspace.h>
 
 
 // Reset the microcontroller
@@ -109,8 +110,8 @@ uint16_t copyBytes(void *dst, uint16_t dst_offset, void *src, uint8_t src_bytes)
  * finds a key and copies its value to the value output pointer
  */
 bool jsonKeyFind(const char *response, const char *key, char *value, uint8_t size) {
-	char *s1 = strstr(response, key);
-	uint8_t len = strlen(key);
+	char *s1 = strstr_P(response, key);
+	uint8_t len = strlen_P(key);
 	if (s1 && len) {
 		char *s2 = strstr(s1 + len + 3, "\"");
 		if (s2) {

--- a/code/uRADMonitor.cpp
+++ b/code/uRADMonitor.cpp
@@ -30,6 +30,7 @@
 #include <string.h>
 #include <stdio.h>
 #include <stdlib.h>
+#include <avr/pgmspace.h>
 
 #include "app/UI.h"
 // local headers

--- a/code/uRADMonitor.cpp
+++ b/code/uRADMonitor.cpp
@@ -389,7 +389,7 @@ void early_run(void) {
 				sprintf_P(buffer, PSTR("\"type\":\"%X\",\"detector\":\"%s\",\"cpm\":%lu,"),DEV_CLASS, aux_detectorName(GEIGER_TUBE), data.getGeigerCPM());
 				dat_p = fill_tcp_data_len(ethBuffer,dat_p, (uint8_t *)buffer, strlen(buffer));
 #ifdef USE_BME280_SENSOR
-				sprintf_P(buffer, PSTR("\"temperature\":%.2f,\"pressure\":%lu,\"humidity\":%.2f,"), data.getTemperature(), data.getPressure(), data.getHumidity());
+				sprintf_P(buffer, PSTR("\"temperature\":%.2f,\"pressure\":%lu,\"humidity\":%u,"), data.getTemperature(), data.getPressure(), data.getHumidity());
 				dat_p = fill_tcp_data_len(ethBuffer,dat_p, (uint8_t *)buffer, strlen(buffer));
 #endif
 				sprintf_P(buffer, PSTR("\"uptime\": %lu}}"), time.getTotalSec());
@@ -410,9 +410,8 @@ void early_run(void) {
 					sprintf_P(buffer, PSTR("Ready in %ds<br><br>"), WARMUP - time.getTotalSec());
 					dat_p = fill_tcp_data_len(ethBuffer,dat_p, (uint8_t *)buffer, strlen(buffer));
 				} else {
-					sprintf_P(buffer, PSTR("temperature:%.2fC<br>pressure:%luPa<br>"), data.getTemperature(), data.getPressure());
+					sprintf_P(buffer, PSTR("temperature:%.2fC<br>pressure:%luPa<br>humidty:%uRH<br>"), data.getTemperature(), data.getPressure(), data.getHumidity());
 					dat_p = fill_tcp_data_len(ethBuffer,dat_p, (uint8_t *)buffer, strlen(buffer));
-					sprintf_P(buffer, PSTR("humidty:%.2fRH<br>"), data.getHumidity());
 				}
 #endif
 				sprintf_P(buffer, PSTR("voltage:%uV<br>duty:%u%%<br>frequency:%.2fkHz<br>"),data.getInverterVoltage(), data.getInverterDuty() /10, INVERTER_FREQUENCY / 1000.0);

--- a/code/uRADMonitor.cpp
+++ b/code/uRADMonitor.cpp
@@ -348,17 +348,17 @@ void early_run(void) {
 					// when sending data, make sure you include the timestamp with each packet, or the server will reject your data
 					// see expProtocol.h for the possible sensors supported by the server
 #ifdef USE_BME280_SENSOR
-					sprintf_P(ethParams, PSTR(ID_TIME_SECONDS"/%lu/"ID_VERSION_HW"/%u/"ID_VERSION_SW"/%u/"
+					sprintf_P(ethParams, PSTR(ID_TIME_SECONDS"/%lu/"ID_VERSION_HW"/%u/"ID_VERSION_SW"/%u/"ID_TUBE_TYPE"/%u/"
 							ID_SBM20_CPM"/%lu/"ID_INVERTERVOLTAGE_VOLTS"/%u/"ID_INVERTERDUTY_PM"/%u/"
 							ID_TEMPERATURE_CELSIUS"/%.2f/"ID_PRESSURE_PASCALS"/%lu/"ID_HUMIDITY_RH"/%u"),
-							time.getTotalSec(), (uint8_t)VER_HW, (uint8_t)VER_SW,
+							time.getTotalSec(), (uint8_t)VER_HW, (uint8_t)VER_SW, (uint8_t)GEIGER_TUBE,
 							data.getGeigerCPM(),data.getInverterVoltage(), data.getInverterDuty(),
 							data.getTemperature(), data.getPressure(), data.getHumidity()
 						);
 #else
-					sprintf_P(ethParams, PSTR(ID_TIME_SECONDS"/%lu/"ID_VERSION_HW"/%u/"ID_VERSION_SW"/%u/"
+					sprintf_P(ethParams, PSTR(ID_TIME_SECONDS"/%lu/"ID_VERSION_HW"/%u/"ID_VERSION_SW"/%u/"ID_TUBE_TYPE"/%u/"
 							ID_SBM20_CPM"/%lu/"ID_INVERTERVOLTAGE_VOLTS"/%u/"ID_INVERTERDUTY_PM"/%u"),
-							time.getTotalSec(), (uint8_t)VER_HW, (uint8_t)VER_SW,
+							time.getTotalSec(), (uint8_t)VER_HW, (uint8_t)VER_SW, (uint8_t)GEIGER_TUBE,
 							data.getGeigerCPM(),data.getInverterVoltage(), data.getInverterDuty()
 						);
 

--- a/code/uRADMonitor.cpp
+++ b/code/uRADMonitor.cpp
@@ -347,16 +347,16 @@ void early_run(void) {
 					// when sending data, make sure you include the timestamp with each packet, or the server will reject your data
 					// see expProtocol.h for the possible sensors supported by the server
 #ifdef USE_BME280_SENSOR
-					sprintf_P(ethParams, PSTR(ID_TIME_SECONDS "/%lu/" ID_VERSION_HW "/%u/" ID_VERSION_SW "/%u/"
-							ID_SBM20_CPM "/%lu/" ID_INVERTERVOLTAGE_VOLTS "/%u/" ID_INVERTERDUTY_PM "/%u/"
-							ID_TEMPERATURE_CELSIUS "/%.2f/" ID_PRESSURE_PASCALS "/%lu/" ID_HUMIDITY_RH "/%u"),
+					sprintf_P(ethParams, PSTR(ID_TIME_SECONDS"/%lu/"ID_VERSION_HW"/%u/"ID_VERSION_SW"/%u/"
+							ID_SBM20_CPM"/%lu/"ID_INVERTERVOLTAGE_VOLTS"/%u/"ID_INVERTERDUTY_PM"/%u/"
+							ID_TEMPERATURE_CELSIUS"/%.2f/"ID_PRESSURE_PASCALS"/%lu/"ID_HUMIDITY_RH"/%u"),
 							time.getTotalSec(), (uint8_t)VER_HW, (uint8_t)VER_SW,
 							data.getGeigerCPM(),data.getInverterVoltage(), data.getInverterDuty(),
 							data.getTemperature(), data.getPressure(), data.getHumidity()
 						);
 #else
-					sprintf_P(ethParams, PSTR(ID_TIME_SECONDS "/%lu/" ID_VERSION_HW "/%u/" ID_VERSION_SW "/%u/"
-												ID_SBM20_CPM "/%lu/" ID_INVERTERVOLTAGE_VOLTS "/%u/" ID_INVERTERDUTY_PM "/%u"),
+					sprintf_P(ethParams, PSTR(ID_TIME_SECONDS"/%lu/"ID_VERSION_HW"/%u/"ID_VERSION_SW"/%u/"
+							ID_SBM20_CPM"/%lu/"ID_INVERTERVOLTAGE_VOLTS"/%u/"ID_INVERTERDUTY_PM"/%u"),
 							time.getTotalSec(), (uint8_t)VER_HW, (uint8_t)VER_SW,
 							data.getGeigerCPM(),data.getInverterVoltage(), data.getInverterDuty()
 						);


### PR DESCRIPTION
My unit kept registering to the network endlessly, showing about 20 new IDs in my dashboard (and a nice email from radhoo in my mailbox that there's something wrong).

Because you've added the PSTR macro to the jsonKeyFind() call in uRADMonitor.cpp:178 the strstr / strlen functions won't work anymore and a ID is assigned by the server on each request but never written to the EEPROM.